### PR TITLE
#17: fix XMPPMessage.Text setter

### DIFF
--- a/SharpXMPP.NUnit/XMPPMessageTests.cs
+++ b/SharpXMPP.NUnit/XMPPMessageTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+using SharpXMPP.XMPP.Client.Elements;
+
+namespace SharpXMPP.NUnit
+{
+    [TestFixture]
+    public class XMPPMessageTests
+    {
+        [Test]
+        [TestCase("hello world")]
+        [TestCase("<xml>")]
+        [TestCase("&lt;")]
+        public void TextShouldBeWritable(string text)
+        {
+            var message = new XMPPMessage {Text = text};
+            Assert.AreEqual(text, message.Text);
+        }
+    }
+}

--- a/SharpXMPP.Shared/XMPP/Client/Elements/XMPPMessage.cs
+++ b/SharpXMPP.Shared/XMPP/Client/Elements/XMPPMessage.cs
@@ -8,7 +8,7 @@ namespace SharpXMPP.XMPP.Client.Elements
         public XMPPMessage()
             : base(XNamespace.Get(Namespaces.JabberClient) + "message")
         {
-            
+
         }
 
         public string Text
@@ -21,7 +21,7 @@ namespace SharpXMPP.XMPP.Client.Elements
             {
                 var body = Element(XNamespace.Get(Namespaces.JabberClient) + "body") ??
                            new XElement(XNamespace.Get(Namespaces.JabberClient) + "body");
-                body.SetValue(new XCData(value));
+                body.SetValue(value);
                 Add(body);
             }
         }


### PR DESCRIPTION
### Impact

Closes #17.

### Investigation

According to [that](https://stackoverflow.com/a/9531809/2684760), `XCData` isn't meant to be used that way. So, it was an actual error.