### PR TITLE
Update NuGet metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.csproj]
+indent_size = 2
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
 # SharpXMPP
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/rxg50qdn6gcxknav/branch/master?svg=true)](https://ci.appveyor.com/project/vitalyster/sharpxmpp/branch/master)
 [![Travis build Status](https://travis-ci.org/vitalyster/SharpXMPP.svg?branch=master)](https://travis-ci.org/vitalyster/SharpXMPP)
-[![NuGet](https://img.shields.io/nuget/v/SharpXMPP.Shared.svg)](https://www.nuget.org/packages/SharpXMPP.Shared/)
+[![NuGet](https://img.shields.io/nuget/v/SharpXMPP.svg)](https://www.nuget.org/packages/SharpXMPP/)
 
 XMPP library for .NET/Xamarin/.NET Core
 
 License: [LGPLv3](LICENSE.md)
 
-Publishing
-----------
+Additional docs
+---------------
 
-If you want to publish the package to NuGet, run the following:
-
-```console
-$ dotnet pack SharpXMPP.Shared -c Release
-```
-
-After that publish the artifact from `SharpXMPP.Shared/bin/Release/*.nupkg`
+- [How to Pack](docs/how-to-pack.md)

--- a/SharpXMPP.Shared/SharpXMPP.Shared.csproj
+++ b/SharpXMPP.Shared/SharpXMPP.Shared.csproj
@@ -1,12 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.0.1-pre02</VersionPrefix>
+    <VersionPrefix>0.0.1</VersionPrefix>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>SharpXMPP.Shared</AssemblyName>
-    <PackageId>SharpXMPP.Shared</PackageId>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>SharpXMPP</PackageId>
+    <Authors>ForNeVeR</Authors>
+    <Description>Managed XMPP (Jabber) client library.</Description>
+    <PackageReleaseNotes>0.0.1 – initial release.</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/vitalyster/SharpXMPP</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/vitalyster/SharpXMPP/blob/276429d82753c255ac62b22a4fc73119e244472e/LICENSE.md</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/vitalyster/SharpXMPP.git</RepositoryUrl>
+    <PackageTags>XMPP; Jabber</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/docs/how-to-pack.md
+++ b/docs/how-to-pack.md
@@ -1,0 +1,10 @@
+How to Pack
+===========
+
+To pack the SharpXMPP and publish it to NuGet, use the following command:
+
+```console
+$ rm -r SharpXMPP.Shared/bin/Release
+$ dotnet pack -c Release SharpXMPP.Shared
+$ dotnet nuget push SharpXMPP.Shared/bin/Release/SharpXMPP.<version>.nupkg -k <NuGet API key> -s https://www.nuget.org/api/v2/package
+```


### PR DESCRIPTION
### Impact

- Renames the NuGet project from `SharpXMPP.Shared` to `SharpXMPP`.
- Releases 0.0.1.
- Closes #13.

### Notes

I'm listed as author in `csproj`, but I'm not claiming I'm the single project author. I haven't listed anyone else because [according to the spec](https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties), `<Authors>` property should include a "semicolon-separated list of packages authors, matching the profile names on nuget.org", and I don't know @vitalyster's NuGet account name.

If it will be available, I'll list his name there, too.