### PR TITLE
NuGet: enable right package source for CI

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Last days, I am seeing this issue on GitHub Actions much. It seems like their global `NuGet.config` is broken somehow, so we'll have to override it in out project.