### PR TITLE
WebSockets: use HTTP Lookup method for XMPP Websocket URI

### DIFF
--- a/SharpXMPP.WebSocket/SharpXMPP.WebSocket.csproj
+++ b/SharpXMPP.WebSocket/SharpXMPP.WebSocket.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DnsClient" Version="1.6.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
 


### PR DESCRIPTION
https://mail.jabber.org/pipermail/standards/2022-February/038759.html

TL;DR: both lookup methods are defined in XEP-0156, but DNS method is "insecure" and we need to switch to HTTP one