### PR TITLE
CI: use setup-dotnet action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,8 +15,8 @@ jobs:
         dotnet-version: '5.0.x'
     - name: Restore dependencies
       run: dotnet restore
-    - name: Run .NET Core tests
-      run: dotnet test SharpXMPP.NUnit --no-restore --configuration Release -f netcoreapp3.1
+    - name: Run .NET 5.0 tests
+      run: dotnet test SharpXMPP.NUnit --no-restore --configuration Release -f net5.0
     - name: Configure Mono
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: '5.0.x'
     - name: Restore dependencies
       run: dotnet restore
     - name: Run .NET Core tests


### PR DESCRIPTION
* This will register provided "problem matchers" to capture errors from tests output
* Use .NET 5 to run tests