### PR TITLE
XmppTcpConnection: fix issue with disposing the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- An exception when trying to call `XmppTcpConnection::Dispose`
+
 ## [0.3.0] - 2021-09-25
 ### Added
 - Separate build for .NET 5

--- a/SharpXMPP.Shared/XmppTcpConnection.cs
+++ b/SharpXMPP.Shared/XmppTcpConnection.cs
@@ -109,15 +109,15 @@ namespace SharpXMPP
             // case of a race condition between the two.
             lock (_terminationLock)
             {
-                // NOTE: Client is explicitly Disposable on older runtimes, so cast is required.
-                ((IDisposable)_client)?.Dispose();
-                _client = null;
                 Writer?.Dispose();
                 Writer = null;
                 Reader?.Dispose();
                 Reader = null;
                 ConnectionStream?.Dispose();
                 ConnectionStream = null;
+                // NOTE: Client is explicitly Disposable on older runtimes, so cast is required.
+                ((IDisposable)_client)?.Dispose();
+                _client = null;
             }
         }
 


### PR DESCRIPTION
Objects based on the connection stream and TCP client should be terminated first.