### PR TITLE
XmppConnection::OnIq: fix a typo which lead to KeyNotFoundException on some results

### DIFF
--- a/SharpXMPP.Shared/XmppConnection.cs
+++ b/SharpXMPP.Shared/XmppConnection.cs
@@ -125,11 +125,10 @@ namespace SharpXMPP
 
         protected void OnIq(XMPPIq e)
         {
-            if (e.IqType == XMPPIq.IqTypes.result
-                || e.IqType == XMPPIq.IqTypes.error
-                && queries.ContainsKey(e.ID))
+            if ((e.IqType == XMPPIq.IqTypes.result || e.IqType == XMPPIq.IqTypes.error)
+                && queries.TryGetValue(e.ID, out var handler))
             {
-                queries[e.ID](e);
+                handler(e);
                 queries.Remove(e.ID);
             }
             else


### PR DESCRIPTION
So, if someone sent an iq query and hasn't set a handler for it, then we only check for the presence of handler on errors, and not on successful result.