### PR TITLE
Moved BookmarkManager to XmppConnection

### DIFF
--- a/SharpXMPP.Shared/XmppClient.cs
+++ b/SharpXMPP.Shared/XmppClient.cs
@@ -21,7 +21,6 @@ namespace SharpXMPP
             RosterManager = new RosterManager(this, autoPresence);	    
         }
 
-        public BookmarksManager BookmarkManager { get; private set; }
         public RosterManager RosterManager { get; private set; }
 
         

--- a/SharpXMPP.Shared/XmppConnection.cs
+++ b/SharpXMPP.Shared/XmppConnection.cs
@@ -9,6 +9,7 @@ using SharpXMPP.XMPP.Client.Capabities;
 using SharpXMPP.XMPP.Client.Disco;
 using SharpXMPP.XMPP.Client.Disco.Elements;
 using SharpXMPP.XMPP.Client.Elements;
+using SharpXMPP.XMPP.Client.MUC.Bookmarks;
 using SharpXMPP.XMPP.Stream.Elements;
 
 namespace SharpXMPP
@@ -82,6 +83,8 @@ namespace SharpXMPP
         public JID Jid { get; set; }
 
 		protected string Password { get; set; }
+
+        public BookmarksManager BookmarkManager { get; protected set; }
 
 		public delegate void ConnectionFailedHandler(XmppConnection sender, ConnFailedArgs e);
 

--- a/SharpXMPP.WebSocket/XmppWebSocketConnection.cs
+++ b/SharpXMPP.WebSocket/XmppWebSocketConnection.cs
@@ -13,6 +13,7 @@ using SharpXMPP.XMPP.Bind.Elements;
 using SharpXMPP.XMPP.Client.Capabities;
 using SharpXMPP.XMPP.Client.Disco.Elements;
 using SharpXMPP.XMPP.Client.Elements;
+using SharpXMPP.XMPP.Client.MUC.Bookmarks;
 using SharpXMPP.XMPP.Framing.Elements;
 using SharpXMPP.XMPP.SASL;
 using SharpXMPP.XMPP.SASL.Elements;
@@ -46,7 +47,7 @@ namespace SharpXMPP
         public XmppWebSocketConnection(JID jid, string password)
         : this (jid, password, string.Empty) { }
 
-        public XmppWebSocketConnection(JID jid, string password, string websocketUri)
+        public XmppWebSocketConnection(JID jid, string password, string websocketUri, bool autoPresence = true)
             : base("")
         {
             this.websocketUri = websocketUri;
@@ -68,6 +69,7 @@ namespace SharpXMPP
                     Namespaces.DiscoItems
                 }
             };
+            BookmarkManager = new BookmarksManager(this, autoPresence);
         }
         public override XElement NextElement()
         {
@@ -107,7 +109,6 @@ namespace SharpXMPP
             _connection.Send(ElementToString(data));
             base.Send(data);
         }
-
 
         public override Task ConnectAsync(CancellationToken token)
         {


### PR DESCRIPTION
This PR moves the BookmarkManager to `XmppConnection` to allow easily connecting to MUC rooms over WebSockets. 

Important to note that the BookmarkManager is not instantiated in the base `XmppConnection` class but only in `XmppClient` and `XmppWebSocketConnection`. Please review and let me know if you find improvements. Thank you!