### PR TITLE
Added support for manual disconnects and properly disposed websocket

### DIFF
--- a/SharpXMPP.Shared/XmppConnection.cs
+++ b/SharpXMPP.Shared/XmppConnection.cs
@@ -95,6 +95,15 @@ namespace SharpXMPP
             ConnectionFailed(this, e);
         }
 
+        public delegate void ConnectionClosedHandler(XmppConnection sender);
+
+        public event ConnectionClosedHandler ConnectionClosed = delegate { };
+
+        protected void OnConnectionClosed()
+        {
+            ConnectionClosed(this);
+        }
+
         public delegate void StreamStartHandler(XmppConnection sender, string streamId);
 
         public event StreamStartHandler StreamStart = delegate { };
@@ -186,5 +195,6 @@ namespace SharpXMPP
 
         public Task ConnectAsync() => ConnectAsync(CancellationToken.None);
         public abstract Task ConnectAsync(CancellationToken token);
+        public abstract void Disconnect();
     }
 }

--- a/SharpXMPP.Shared/XmppTcpConnection.cs
+++ b/SharpXMPP.Shared/XmppTcpConnection.cs
@@ -105,8 +105,8 @@ namespace SharpXMPP
 
         private void TerminateTcpConnection()
         {
-            // There are two callers for this method: connection timeout and external dispose. This lock is placed in
-            // case of a race condition between the two.
+            // There are three callers for this method: connection timeout, external disconnect, and external dispose.
+            // This lock is placed in case of a race condition between the two.
             lock (_terminationLock)
             {
                 Writer?.Dispose();
@@ -345,6 +345,12 @@ namespace SharpXMPP
                 cancellationToken);
             RestartXmlStreams();
             return true;
+        }
+
+        public override void Disconnect()
+        {
+            TerminateTcpConnection();
+            OnConnectionClosed();
         }
     }
 }


### PR DESCRIPTION
This PR adds support for manually disconnecting XMPP connections. It also adds a `ConnectionClosed` event and handler that callers can subscribe to. In addition, it fixes memory leaks in `XmppWebSocketConnection` by overriding `Dispose` and disposing the existing WebSocket connection before instantiating a new one in `ConnectAsync`.

Relates to https://github.com/vitalyster/SharpXMPP/issues/164