### PR TITLE
Added a Nick setter in BookmarkedConference

### DIFF
--- a/SharpXMPP.Shared/XMPP/Client/MUC/Bookmarks/Elements/BookmarkedConference.cs
+++ b/SharpXMPP.Shared/XMPP/Client/MUC/Bookmarks/Elements/BookmarkedConference.cs
@@ -35,6 +35,7 @@ namespace SharpXMPP.XMPP.Client.MUC.Bookmarks.Elements
                 var nick = Element(XNamespace.Get(Namespaces.StorageBookmarks) + "nick");
                 return nick == null ? null : nick.Value;
             }
+            set => SetAttributeValue(XNamespace.Get(Namespaces.StorageBookmarks) + "nick", value);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a setter to the `Nick` property of `BookmarkedConference` for convenience.  It also renames `BookmarkedConference` to fix a typo in its filename.