### PR TITLE
Fixed Nick setter in BookmarkManager

### DIFF
--- a/SharpXMPP.Shared/XMPP/Client/MUC/Bookmarks/Elements/BookmarkedConference.cs
+++ b/SharpXMPP.Shared/XMPP/Client/MUC/Bookmarks/Elements/BookmarkedConference.cs
@@ -35,7 +35,19 @@ namespace SharpXMPP.XMPP.Client.MUC.Bookmarks.Elements
                 var nick = Element(XNamespace.Get(Namespaces.StorageBookmarks) + "nick");
                 return nick == null ? null : nick.Value;
             }
-            set => SetAttributeValue(XNamespace.Get(Namespaces.StorageBookmarks) + "nick", value);
+            set
+            {
+                var nick = Element(XNamespace.Get(Namespaces.StorageBookmarks) + "nick");
+
+                if (nick == null)
+                {
+                    Add(new XElement(XNamespace.Get(Namespaces.StorageBookmarks) + "nick", value));
+                }
+                else
+                {
+                    nick.Value = value;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes the Nick setter in BookmarkManager. It replaces using `SetAttributeValue` with adding the Nick as a child element instead, as the Nick should not be an attribute.

@vitalyster @ForNeVeR I'd like to request a patch release on NuGet if this looks good. Thank you very much!